### PR TITLE
Adding deprecation info for d2l-course-image-tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is an interim repository for components that have not yet been upgraded to class-based Polymer 2 (or Polymer 3). Anything that lives here will only be here for a short time, and this repo in its entirety is intended to be short-lived.
 
 Once the LMS is using Polymer 2 (or 3), this repo is no longer required, and components should be added to the respective top-level repositories of BrightspaceHypermediaComponents.
+
+## d2l-course-image-tile
+
+`d2l-course-image-tile` has been replaced by `d2l-enrollment-card`, which you can find here: https://github.com/BrightspaceHypermediaComponents/enrollments/.


### PR DESCRIPTION
I noticed someone asking in Slack about where the new location of `d2l-course-image-tile` is, thought maybe a quick README update might help others.